### PR TITLE
updated readme to have the system run on linux + fixed a few artifact…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data*
 .idea
 mock_data/
 agent
+results/*

--- a/clue-config.yaml
+++ b/clue-config.yaml
@@ -1,10 +1,10 @@
 config:
   prometheus_url: "http://localhost:9090"  # minikube
-  docker_user: "host.docker.internal:6789/clue"
+  docker_user: "host.minikube.internal:6789/clue"
   local_public_ip: "cluereg.local"
   local_port: 8888
   remote_platform_arch: "linux/arm64/v8"
   local_platform_arch: "linux/amd64"
-  docker_registry_address: "host.docker.internal:6789/clue"
+  docker_registry_address: "host.minikube.internal:6789/clue"
   result_base_path: "results/"
   workloads: ["shaped"]


### PR DESCRIPTION
I have the system finally run on linux. Instead of host.docker.internal (which only works for mac and windows apparently) you have to use host.minikube.internal to access the local host machine. I also modified the readme a bit and added more information.