### PR TITLE
Implement tags for each of the experiments in teastore/build.py

### DIFF
--- a/clue_builders/teastore/build.py
+++ b/clue_builders/teastore/build.py
@@ -172,7 +172,7 @@ def build_workload(experiment):
                 "-t", tag,
                 ".",
             ],
-            cwd=path.join("workload-generator"),
+            cwd=path.join("workload_generator"),
         )
         if build != 0:
             raise RuntimeError("Failed to build the workload generator")


### PR DESCRIPTION
This pull request completes the work for issue https://github.com/clue2-sose25/Clue2/issues/11 by ensuring that each experiment image is properly tagged and invoked with the correct parameters:

patch_buildx: Adjusted to add the image tag at the patch stage.
build_workload: Extended to include the tag .
Main logic: Added support to call the Python script with the --exp flag.
Invocation points: Updated all call sites to supply the previously missing parameters.
These changes enable clearer separation and labeling of experiment images throughout the build process.