### PR TITLE
Extend the workload selection #107 &  Change the check mark buttons to white background #110

### DIFF
--- a/clue_webui/src/contexts/DeploymentContext.tsx
+++ b/clue_webui/src/contexts/DeploymentContext.tsx
@@ -6,7 +6,7 @@ import type {DeploymentForm} from "../models/DeploymentForm";
 const defaultDeploymentForm: DeploymentForm = {
   SutName: null,
   experimentNames: [],
-  workload: "shaped",
+  workloads: ["shaped"],
   iterations: 1,
   deploy_only: false,
 };

--- a/clue_webui/src/models/DeploymentForm.ts
+++ b/clue_webui/src/models/DeploymentForm.ts
@@ -1,16 +1,34 @@
 export type Workload = "shaped" | "rampup" | "pausing" | "fixed";
 
-export const workloadOptions: Workload[] = [
-  "shaped",
-  "rampup",
-  "pausing",
-  "fixed",
+export interface WorkloadOption {
+  name: Workload;
+  description: string;
+}
+
+export const workloadOptions: WorkloadOption[] = [
+  {
+    name: "shaped",
+    description: "Workload with custom load shape behavior.",
+  },
+  {
+    name: "rampup",
+    description: "Workload that ramps up users at a constant rate.",
+  },
+  {
+    name: "pausing",
+    description: "Workload that starts 20 pausing users with no ramp-up.",
+  },
+  {
+    name: "fixed",
+    description:
+      "Workload that ramps to max users for a fixed number of requests.",
+  },
 ];
 
 export interface DeploymentForm {
   SutName: string | null;
   experimentNames: string[];
-  workload: Workload;
+  workloads: Workload[];
   iterations: number;
   deploy_only: boolean;
 }

--- a/clue_webui/src/pages/DashboardPage.tsx
+++ b/clue_webui/src/pages/DashboardPage.tsx
@@ -66,7 +66,7 @@ const DashboardPage = () => {
     },
     {
       label: "Workload Type",
-      value: currentDeployment.workload,
+      value: currentDeployment.workloads.join(", "),
       icon: <LightningIcon size={24} />,
     },
     {


### PR DESCRIPTION
It is now possible to select multiple options in the Workload Selection. Additionally, the checkboxes have been adjusted to have a white background. A "Select All" button has also been added for Workloads & Experiments selection.

![image](https://github.com/user-attachments/assets/1a768748-46c3-48d9-9002-d0eaf1a7d66e)
