### PR TITLE
Cleanup logging, fixed loadgenerator cleanup

### DIFF
--- a/clue_deployer/src/experiment_runner.py
+++ b/clue_deployer/src/experiment_runner.py
@@ -13,7 +13,6 @@ from clue_deployer.src.service.status_manager import StatusManager, StatusPhase
 from os import path
 import signal
 import kubernetes
-import logging
 from kubernetes.client.rest import ApiException
 from clue_deployer.src.logger import logger
 
@@ -62,7 +61,7 @@ class ExperimentRunner:
 
         # 5. start workload
         # start resource tracker
-        logging.debug("starting tracker")
+        logger.info("Starting resource tracker")
         tracker.start()
 
         # MAIN timeout to kill the experiment after 2 min after the experiment should be over (to avoid hanging)
@@ -82,7 +81,6 @@ class ExperimentRunner:
                 signal.raise_signal(signal.SIGUSR1)  # raise SIGUSR1 on Unix-like systems
             else:
                 raise WorkloadCancelled("Workload cancelled")  # raise custom exception on Windows
-            logging.warning(f"workload timeout ({timeout})s reached.")
             StatusManager.set(StatusPhase.DONE, " workload timeout reached, Done :)")
             raise SystemExit(0)  # Exit gracefully
 
@@ -107,8 +105,8 @@ class ExperimentRunner:
 
         # Example usage
         try:
-            logging.info(f"starting workload with timeout {timeout}")
-            StatusManager.set(StatusPhase.IN_PROGRESS, "starting workload with time out, Experiment in progress...")
+            logger.info(f"Experiment started, deploying workload with timeout {timeout}s...")
+            StatusManager.set(StatusPhase.IN_PROGRESS, "Starting workload with time out, Experiment in progress...")
             # Set up the timeout
             timer = set_timeout(timeout)
 
@@ -117,10 +115,10 @@ class ExperimentRunner:
             # will run remotely or locally based on experiment
             try:
                 wlr.run_workload(observations_out_path)
-            except WorkloadCancelled:
-                logging.info("Workload stopped due to cancellation")
+            except WorkloadCancelled as e:
+                logger.warning("Workload was cancelled due to exception: " + str(e))
             StatusManager.set(StatusPhase.DONE, " Expermint Done, flushing channels :)")
-            logging.info("finished running workload, stopping trackers and flushing channels")
+            logger.info("Finished running workload, stopping trackers and flushing channels")
             # stop resource tracker
             tracker.stop()
             node_channel.flush()
@@ -140,7 +138,6 @@ class ExperimentRunner:
         """
         Remove sets for autoscaling, remove workload pods,
         """
-        print("🧹 Cleaning up...")
         logger.info("🧹 Cleaning up deployments...")
 
         if self.experiment.autoscaling:
@@ -167,7 +164,6 @@ class ExperimentRunner:
                 else:
                     logger.error(f"Error checking or deleting pod:" + str(e))
             except Exception as e:
-                logging.error("Error cleaning up. Probably already deleted: " + str(e))
                 logger.error("Error cleaning up. Probably already deleted: " + str(e))
                 pass
         

--- a/clue_deployer/src/experiment_runner.py
+++ b/clue_deployer/src/experiment_runner.py
@@ -121,14 +121,15 @@ class ExperimentRunner:
             tracker.stop()
             node_channel.flush()
             pod_channel.flush()
-
         except SystemExit:
-            # Clean up
-            if platform.system() == "Windows" and timer:
-                timer.cancel()  # Cancel the Windows timer
-            elif platform.system() != "Windows":
-                signal.alarm(0)  # Disable SIGALRM on Unix-like systems
-            logging.info("Program terminated")
+            _ = None  # Ignore SystemExit raised by the cancel function and clean up gracefully
+
+        logger.info("Cleaning up timers after the experiment")
+        # Clean up
+        if platform.system() == "Windows" and timer:
+            timer.cancel()  # Cancel the Windows timer
+        elif platform.system() != "Windows":
+            signal.alarm(0)  # Disable SIGALRM on Unix-like systems
 
 
     def cleanup(self, helm_wrapper: HelmWrapper):

--- a/clue_deployer/src/experiment_runner.py
+++ b/clue_deployer/src/experiment_runner.py
@@ -71,6 +71,10 @@ class ExperimentRunner:
         # noinspection PyUnusedLocal
         def cancel(sig=None, frame=None):
             """Handler for timeout, SIGINT, or manual cancellation."""
+            if StatusManager.get() == StatusPhase.DONE:
+                logger.info("Reached timout but experiment is already done, skipping cancellation.")
+                return
+            logger.warning(f"Workload timeout of {timeout}s reached, stopping the experiment.")
             tracker.stop()
             pod_channel.flush()
             node_channel.flush()

--- a/clue_deployer/src/main.py
+++ b/clue_deployer/src/main.py
@@ -119,8 +119,9 @@ class ClueRunner:
         StatusManager.set(StatusPhase.PREPARING_CLUSTER, "Preparing the cluster...")
         # Deploy a single experiment if deploy only
         if self.deploy_only:
-            logger.info(f"Starting experiment: {exps.experiments[0]}")
+            logger.info(f"Starting deployment only for experiment: {exps.experiments[0]}")
             self.run_single_experiment(exps.experiments[0])
+            logger.info("Deployment executed successfully. Exiting CLUE.")
         else:
             # Get the workloads
             logger.info("Appending workloads to the experiments")

--- a/clue_deployer/src/main.py
+++ b/clue_deployer/src/main.py
@@ -78,13 +78,6 @@ class ClueRunner:
             # Clean up
             logger.info("Cleaning up after the experiment")
             ExperimentRunner(exp).cleanup(experiment_deployer.helm_wrapper)
-            logger.info(f"Waiting {exp.env.wait_after_workloads}s after cleaning the workload")
-            time.sleep(exp.env.wait_after_workloads)
-            logger.info("Waiting 60 sleep after a run just to be on the safe side")
-            time.sleep(60)
-            logger.info("All benchmarks executed successfully. Exiting CLUE.")
-        else:
-            logger.info("Deployment tested successfully. Exiting CLUE.")
 
 
     def iterate_single_experiment(self, exp: Experiment, timestamp: str) -> None:
@@ -101,9 +94,10 @@ class ClueRunner:
             out_path = path.join(root, timestamp, tags, name, str(i))
             logger.info(f"Running iteration ({i + 1}/{num_iterations}) with output to: {out_path}")
             self.run_single_experiment(exp, out_path)
-        # Wait
-        logger.info(f"Sleeping for 120s to let the system settle after one experiment")
-        time.sleep(120)
+            # additional wait after each iteration except the last one
+            if i < num_iterations - 1:
+                logger.info(f"Sleeping {exp.env.wait_after_workloads} seconds before next experiment iteration")
+                time.sleep(exp.env.wait_after_workloads)
 
     def main(self) -> None:
         logger.info(f"Starting CLUE with DEPLOY_ONLY={self.deploy_only}")
@@ -143,6 +137,12 @@ class ClueRunner:
             # Run over all iterations of each of the experiments
             for exp in exps:
                 self.iterate_single_experiment(exp, timestamp)
+                # additional wait after each experiment except the last one
+                if exp != exps.experiments[-1]:
+                    logger.info(f"Sleeping additional {exp.env.wait_after_workloads} seconds before starting next experiment")
+                    time.sleep(exp.env.wait_after_workloads)
+                                
+            logger.info("All experiments executed successfully. Exiting CLUE.")
 
 
 if __name__ == "__main__":

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -5,6 +5,11 @@ networking:
   apiServerPort: 6443
 nodes:
   - role: control-plane
+    extraMounts:
+      - hostPath: /proc
+        containerPath: /proc-host
+      - hostPath: /usr/src
+        containerPath: /usr/src
   - role: worker
     kubeadmConfigPatches:
       - |


### PR DESCRIPTION
This PR includes:
- The fix for kepler on unix systems
- The fix for trying to delete the already deleted loadgenerator pod after the experiment as well after the timout is reached
- Fixed not cleaning up timeout timers after an experiment
- Moved sleeps from methods up to parent loop for better visibility & avoiding waiting in last iterations
- Updated to use clue logger across the deployer
- Updated some logging texts