### PR TITLE
Extend the functionality of SUTs configs #111

### DIFF
--- a/clue_webui/package-lock.json
+++ b/clue_webui/package-lock.json
@@ -13,10 +13,12 @@
         "@mui/material": "^7.1.1",
         "@phosphor-icons/react": "^2.1.10",
         "@tailwindcss/vite": "^4.1.8",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "date-fns": "^4.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router": "^7.6.1",
+        "react-syntax-highlighter": "^5.8.0",
         "tailwindcss": "^4.1.8"
       },
       "devDependencies": {
@@ -2045,6 +2047,15 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.12",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
@@ -2420,6 +2431,16 @@
         "npm": ">=6"
       }
     },
+    "node_modules/babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2591,6 +2612,14 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "hasInstallScript": true,
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -3021,6 +3050,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3090,6 +3132,14 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3183,6 +3233,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha512-qNnYpBDO/FQwYVur1+sQBQw7v0cxso1nOYLklqWh6af8ROwwTVoII5+kf/BVa8354WL4ad6rURHYGUXCbD9mMg==",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -3670,6 +3730,16 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lowlight": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
+      "integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^1.0.2",
+        "highlight.js": "~9.12.0"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4088,6 +4158,20 @@
         }
       }
     },
+    "node_modules/react-syntax-highlighter": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-5.8.0.tgz",
+      "integrity": "sha512-+FolT9NhFBqE4SsZDelSzsYJJS/JCnQqo4+GxLrFPoML548uvr8f4Eh5nnd5o6ERKFW7ryiygOX9SPnxdnlpkg==",
+      "license": "MIT",
+      "dependencies": {
+        "babel-runtime": "^6.18.0",
+        "highlight.js": "~9.12.0",
+        "lowlight": "~1.9.1"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -4103,6 +4187,12 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/clue_webui/package.json
+++ b/clue_webui/package.json
@@ -15,10 +15,12 @@
     "@mui/material": "^7.1.1",
     "@phosphor-icons/react": "^2.1.10",
     "@tailwindcss/vite": "^4.1.8",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "date-fns": "^4.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.6.1",
+    "react-syntax-highlighter": "^5.8.0",
     "tailwindcss": "^4.1.8"
   },
   "devDependencies": {

--- a/clue_webui/src/App.tsx
+++ b/clue_webui/src/App.tsx
@@ -6,6 +6,7 @@ import DashboardPage from "./pages/DashboardPage";
 import HomePage from "./pages/HomePage";
 import ClusterConfigPage from "./pages/SettingsPage";
 import ResultsPage from "./pages/ResultsPage";
+import AddSutPage from "./pages/AddSutPage";
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/experiment" element={<ExperimentPage />} />
+          <Route path="/experiment/add-sut" element={<AddSutPage />} />
           <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/results" element={<ResultsPage />} />
           <Route path="/results/:uuid" element={<ResultPage />} />

--- a/clue_webui/src/pages/AddSutPage.tsx
+++ b/clue_webui/src/pages/AddSutPage.tsx
@@ -2,16 +2,23 @@ import {useEffect, useState} from "react";
 import {Link, useNavigate} from "react-router";
 import {ArrowLeftIcon, UploadSimpleIcon} from "@phosphor-icons/react";
 
+// React Syntax Highlighter imports
+import SyntaxHighlighter from "react-syntax-highlighter";
+import {github} from "react-syntax-highlighter/dist/esm/styles/hljs";
+
 const AddSutPage = () => {
   const [file, setFile] = useState<File | null>(null);
   const [content, setContent] = useState<string>("");
   const [sutName, setSutName] = useState<string>("");
+  const [displayName, setDisplayName] = useState<string>("");
   const navigate = useNavigate();
 
   const parseSutName = (yaml: string) => {
     const match = yaml.match(/^\s*sut:\s*"?([A-Za-z0-9-_]+)"?/m);
     if (match) {
-      setSutName(match[1]);
+      const name = match[1];
+      setSutName(name);
+      setDisplayName(name.endsWith(".yaml") ? name : `${name}.yaml`);
     }
   };
 
@@ -47,11 +54,19 @@ const AddSutPage = () => {
     }
   };
 
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setDisplayName(value);
+    // Remove .yaml extension for internal sutName
+    setSutName(value.replace(/\.yaml$/, ""));
+  };
+
   const addSut = async () => {
     let yaml = content;
-    if (sutName) {
+    const finalName = sutName || displayName.replace(/\.yaml$/, "");
+    if (finalName) {
       if (yaml.match(/^\s*sut:/m)) {
-        yaml = yaml.replace(/^\s*sut:\s*.*$/m, `  sut: "${sutName}"`);
+        yaml = yaml.replace(/^\s*sut:\s*.*$/m, `  sut: "${finalName}"`);
       }
     }
     const encoded = btoa(yaml);
@@ -65,51 +80,170 @@ const AddSutPage = () => {
     }
   };
 
+  // Custom theme for YAML syntax highlighting
+  const customYamlTheme = {
+    ...github,
+    hljs: {
+      ...github["hljs"],
+      background: "transparent",
+      padding: "0",
+      fontFamily:
+        'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+      fontSize: "14px",
+      lineHeight: "1.5",
+    },
+    "hljs-comment": {
+      color: "#10B981",
+      fontStyle: "italic",
+    },
+    "hljs-string": {
+      color: "#F59E0B",
+    },
+    "hljs-number": {
+      color: "#8B5CF6",
+    },
+    "hljs-literal": {
+      color: "#8B5CF6",
+    },
+    "hljs-attr": {
+      color: "#3B82F6",
+      fontWeight: "600",
+    },
+    "hljs-bullet": {
+      color: "#6B7280",
+    },
+  };
+
   return (
-    <div className="w-full h-full flex flex-col gap-4 p-4 overflow-y-auto">
+    <div className="w-full h-full flex flex-col gap-3 p-4 overflow-y-auto">
       <Link
         to="/experiment"
         className="flex gap-2 items-center text-sm text-gray-600 hover:underline"
       >
         <ArrowLeftIcon /> Back
       </Link>
-      <div
-        className="border-2 border-dashed rounded p-6 flex flex-col items-center justify-center text-center gap-2"
-        onDragOver={(e) => e.preventDefault()}
-        onDrop={onDrop}
-      >
-        <p className="text-sm">Drag and drop a SUT config file here</p>
-        <label className="bg-blue-500 text-white px-4 py-2 rounded cursor-pointer" >
-          Choose File
-          <input type="file" className="hidden" onChange={onFileChange} />
-        </label>
-        {file && <p className="text-xs text-gray-600">{file.name}</p>}
-      </div>
-      <div className="flex flex-col gap-2">
-        <label className="text-sm font-medium" htmlFor="sut-name-input">
-          SUT Name
-        </label>
-        <input
-          id="sut-name-input"
-          className="border p-2"
-          type="text"
-          value={sutName}
-          onChange={(e) => setSutName(e.target.value)}
-        />
-      </div>
-      <textarea
-        className="border p-2 font-mono text-sm w-full h-64"
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-      ></textarea>
-      <div className="flex w-full justify-center">
-        <button
-          type="button"
-          className="flex items-center gap-2 bg-blue-500 hover:bg-blue-600 text-white rounded shadow px-4 py-2"
-          onClick={addSut}
-        >
-          <UploadSimpleIcon size={16} /> Add SUT
-        </button>
+
+      <div className="flex gap-6 flex-1 min-h-0">
+        {/* Left Column - Controls */}
+        <div className="flex flex-col gap-3 w-1/3 pr-4">
+          <label className="text-sm font-medium" htmlFor="sut-name-input">
+            Create new SUT config
+          </label>
+          {/* Hints Section */}
+          <p className="text-xs text-gray-600">
+            If you have an existing config file, you can select it below to
+            edit. Note that loading a file will replace the current content in
+            the text area.
+          </p>
+
+          {/* Compact File Upload Area */}
+          <div
+            className="border-2 border-dashed border-gray-300 rounded-lg p-4 flex flex-col items-center justify-center text-center gap-2 hover:border-gray-400 transition-colors"
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={onDrop}
+          >
+            <p className="text-sm text-gray-600">
+              Drag and drop existing SUT config
+            </p>
+            <label className="bg-blue-500 text-white px-3 py-1.5 rounded cursor-pointer text-sm hover:bg-blue-600 transition-colors">
+              Choose File
+              <input
+                type="file"
+                className="hidden"
+                onChange={onFileChange}
+                accept=".yaml,.yml"
+              />
+            </label>
+            {file && <p className="text-xs text-gray-500">{file.name}</p>}
+          </div>
+
+          {/* Compact SUT Name Input */}
+          <div className="flex flex-col gap-1">
+            <label className="text-sm font-medium" htmlFor="sut-name-input">
+              File name
+            </label>
+            <input
+              id="sut-name-input"
+              className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              type="text"
+              value={displayName}
+              onChange={handleNameChange}
+              placeholder="Enter SUT name"
+              onBlur={(e) => {
+                const value = e.target.value;
+                if (value && !value.endsWith(".yaml")) {
+                  setDisplayName(value + ".yaml");
+                }
+              }}
+            />
+          </div>
+
+          {/* Submit Button */}
+          <div className="flex w-full justify-center pt-2">
+            <button
+              type="button"
+              className="flex items-center gap-2 bg-blue-500 hover:bg-blue-600 text-white rounded-lg shadow px-4 py-2 transition-colors"
+              onClick={addSut}
+            >
+              <UploadSimpleIcon size={16} /> Upload the SUT config
+            </button>
+          </div>
+        </div>
+
+        {/* Right Column - YAML Editor */}
+        <div className="flex-1 flex flex-col gap-2 min-h-0">
+          <label className="text-sm font-medium">Configuration (YAML)</label>
+          <div className="flex-1 relative border border-gray-300 rounded-lg overflow-hidden bg-white">
+            {/* Syntax Highlighted Background */}
+            <div className="absolute inset-0 p-3 pointer-events-none overflow-auto">
+              <SyntaxHighlighter
+                language="yaml"
+                style={customYamlTheme}
+                customStyle={{
+                  background: "transparent",
+                  padding: "0",
+                  margin: "0",
+                  fontSize: "14px",
+                  lineHeight: "1.5",
+                  fontFamily:
+                    'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                }}
+                showLineNumbers={false}
+                wrapLines={false}
+                PreTag="div"
+                CodeTag="div"
+              >
+                {content || " "}
+              </SyntaxHighlighter>
+            </div>
+
+            {/* Actual textarea */}
+            <textarea
+              className="absolute inset-0 w-full h-full p-3 font-mono text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-inset bg-transparent caret-black"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="Enter your YAML configuration here..."
+              spellCheck={false}
+              style={{
+                fontFamily:
+                  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                lineHeight: "1.5",
+                tabSize: 2,
+                color: "rgba(0, 0, 0, 0.01)", // Almost transparent so highlighting shows through
+              }}
+              onScroll={(e) => {
+                // Sync scroll position with highlight layer
+                const target = e.target as HTMLTextAreaElement;
+                const highlightLayer =
+                  target.previousElementSibling as HTMLDivElement;
+                if (highlightLayer) {
+                  highlightLayer.scrollTop = target.scrollTop;
+                  highlightLayer.scrollLeft = target.scrollLeft;
+                }
+              }}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/clue_webui/src/pages/AddSutPage.tsx
+++ b/clue_webui/src/pages/AddSutPage.tsx
@@ -4,7 +4,6 @@ import {ArrowLeftIcon, UploadSimpleIcon} from "@phosphor-icons/react";
 
 // React Syntax Highlighter imports
 import SyntaxHighlighter from "react-syntax-highlighter";
-import {github} from "react-syntax-highlighter/dist/esm/styles/hljs";
 
 const AddSutPage = () => {
   const [file, setFile] = useState<File | null>(null);
@@ -82,9 +81,7 @@ const AddSutPage = () => {
 
   // Custom theme for YAML syntax highlighting
   const customYamlTheme = {
-    ...github,
     hljs: {
-      ...github["hljs"],
       background: "transparent",
       padding: "0",
       fontFamily:

--- a/clue_webui/src/pages/AddSutPage.tsx
+++ b/clue_webui/src/pages/AddSutPage.tsx
@@ -1,0 +1,118 @@
+import {useEffect, useState} from "react";
+import {Link, useNavigate} from "react-router";
+import {ArrowLeftIcon, UploadSimpleIcon} from "@phosphor-icons/react";
+
+const AddSutPage = () => {
+  const [file, setFile] = useState<File | null>(null);
+  const [content, setContent] = useState<string>("");
+  const [sutName, setSutName] = useState<string>("");
+  const navigate = useNavigate();
+
+  const parseSutName = (yaml: string) => {
+    const match = yaml.match(/^\s*sut:\s*"?([A-Za-z0-9-_]+)"?/m);
+    if (match) {
+      setSutName(match[1]);
+    }
+  };
+
+  useEffect(() => {
+    fetch("/api/suts/raw/default_sut")
+      .then((r) => r.text())
+      .then((t) => {
+        setContent(t);
+        parseSutName(t);
+      })
+      .catch(() => {});
+  }, []);
+
+  const loadFile = async (f: File) => {
+    const text = await f.text();
+    setContent(text);
+    setFile(f);
+    parseSutName(text);
+  };
+
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (f) {
+      void loadFile(f);
+    }
+  };
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const f = e.dataTransfer.files?.[0];
+    if (f) {
+      void loadFile(f);
+    }
+  };
+
+  const addSut = async () => {
+    let yaml = content;
+    if (sutName) {
+      if (yaml.match(/^\s*sut:/m)) {
+        yaml = yaml.replace(/^\s*sut:\s*.*$/m, `  sut: "${sutName}"`);
+      }
+    }
+    const encoded = btoa(yaml);
+    const res = await fetch("/api/suts", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({sut_config: encoded}),
+    });
+    if (res.ok) {
+      navigate("/experiment");
+    }
+  };
+
+  return (
+    <div className="w-full h-full flex flex-col gap-4 p-4 overflow-y-auto">
+      <Link
+        to="/experiment"
+        className="flex gap-2 items-center text-sm text-gray-600 hover:underline"
+      >
+        <ArrowLeftIcon /> Back
+      </Link>
+      <div
+        className="border-2 border-dashed rounded p-6 flex flex-col items-center justify-center text-center gap-2"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={onDrop}
+      >
+        <p className="text-sm">Drag and drop a SUT config file here</p>
+        <label className="bg-blue-500 text-white px-4 py-2 rounded cursor-pointer" >
+          Choose File
+          <input type="file" className="hidden" onChange={onFileChange} />
+        </label>
+        {file && <p className="text-xs text-gray-600">{file.name}</p>}
+      </div>
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium" htmlFor="sut-name-input">
+          SUT Name
+        </label>
+        <input
+          id="sut-name-input"
+          className="border p-2"
+          type="text"
+          value={sutName}
+          onChange={(e) => setSutName(e.target.value)}
+        />
+      </div>
+      <textarea
+        className="border p-2 font-mono text-sm w-full h-64"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      ></textarea>
+      <div className="flex w-full justify-center">
+        <button
+          type="button"
+          className="flex items-center gap-2 bg-blue-500 hover:bg-blue-600 text-white rounded shadow px-4 py-2"
+          onClick={addSut}
+        >
+          <UploadSimpleIcon size={16} /> Add SUT
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AddSutPage;

--- a/clue_webui/src/pages/ExperimentPage.tsx
+++ b/clue_webui/src/pages/ExperimentPage.tsx
@@ -7,7 +7,7 @@ import {
 } from "@phosphor-icons/react";
 import type {SUT} from "../models/SUT";
 import {IconButton, Tooltip} from "@mui/material";
-import {useNavigate} from "react-router";
+import {Link, useNavigate} from "react-router";
 import {QueueContext} from "../contexts/QueueContext";
 
 const ExperimentPage = () => {
@@ -178,7 +178,7 @@ const ExperimentPage = () => {
               <div className="flex justify-start w-full items-center">
                 <span>System Under Test (SUT)</span>
                 <Tooltip title="Add a custom SUT config" arrow placement="top">
-                  <IconButton>
+                  <IconButton component={Link} to="/experiment/add-sut">
                     <PlusCircleIcon size={20} />
                   </IconButton>
                 </Tooltip>

--- a/sut_configs/default_sut.yaml
+++ b/sut_configs/default_sut.yaml
@@ -1,10 +1,10 @@
 # Default SUT configuration template based on teastore.yaml
 
 config:
-  # The name of the SUT  
-  sut: "default-sut"
+  # The name of the SUT
+  sut: "teastore"
   # The K8s namespace to deploy the SUT
-  namespace: "default"
+  namespace: "teastore"
   # The Git repository url for the SUT code
   sut_git_repo: "https://github.com/ISE-TU-Berlin/sustainable_teastore.git"
   # The path to the root folder of the repo after cloning
@@ -16,12 +16,12 @@ config:
   # The values file to use
   values_yaml_name: "values.yaml"
   # The k8s service name (used for in-cluster communication)
-  target_service_name: "teastore-webui" 
+  target_service_name: "teastore-webui"
   # The specific path
-  application_endpoint_path: "/tools.descartes.teastore.webui" 
+  application_endpoint_path: "/tools.descartes.teastore.webui"
   # Default resource limits for all services (used if autoscaling is enabled)
   default_resource_limits:
-    # CPU resource limit 
+    # CPU resource limit
     cpu: 1000
     # Memory resource limit
     memory: 1024
@@ -33,7 +33,7 @@ config:
 ### HELM CHART REPLACEMENTS ###
 # The replacements for the Helm chart values file.
 # Can be used for any arbirary value. It will replace all instances of that value in the whole values file.
-# The replacement will be applied only when all conditions are meet. 
+# The replacement will be applied only when all conditions are meet.
 # The `__EXPERIMENT_TAG__` placeholder will be replaces with the name of the variant. Additionally, it will be used as a tag for the docker images.
 # Required fields:
 #   value: str - the old value to replace
@@ -103,7 +103,7 @@ resource_limits:
 ### WORKLOADS ###
 # A list of workloads for the SUT. Required fields:
 # name: str - a short name of the variant
-# description: str - a short description of the variant 
+# description: str - a short description of the variant
 # timeout_duration: int - the total timeout for the workload generator
 # workload_settings: JSON - settings for the Locust workload generator. See default SUTs' configs for more detail.
 workloads:
@@ -155,7 +155,7 @@ workloads:
 ### VARIANTS ###
 # A list of variants for the SUT. Required fields:
 # name: str - a short name of the variant
-# description: str - a short description of the variant 
+# description: str - a short description of the variant
 # target_branch: str - the name of the git repository branch for the variant
 # colocated_workload: bool - if the workload should be deployed in the cluster or on host machine
 # critical_services: list[str] - a list of the names of the critical services to wait for before running the workload

--- a/sut_configs/default_sut.yaml
+++ b/sut_configs/default_sut.yaml
@@ -1,0 +1,175 @@
+# Default SUT configuration template based on teastore.yaml
+
+config:
+  # The name of the SUT  
+  sut: "default-sut"
+  # The K8s namespace to deploy the SUT
+  namespace: "default"
+  # The Git repository url for the SUT code
+  sut_git_repo: "https://github.com/ISE-TU-Berlin/sustainable_teastore.git"
+  # The path to the root folder of the repo after cloning
+  sut_path: "teastore"
+  # The path to the helm chart folder for deployment
+  helm_chart_path: "teastore/examples/helm"
+  # Optional url to the Git repository for the helm chart. Leave empty if it is the same repo as the SUT.
+  helm_chart_repo: ""
+  # The values file to use
+  values_yaml_name: "values.yaml"
+  # The k8s service name (used for in-cluster communication)
+  target_service_name: "teastore-webui" 
+  # The specific path
+  application_endpoint_path: "/tools.descartes.teastore.webui" 
+  # Default resource limits for all services (used if autoscaling is enabled)
+  default_resource_limits:
+    # CPU resource limit 
+    cpu: 1000
+    # Memory resource limit
+    memory: 1024
+  # The time to wait before deploying individual workloads. Specified in seconds
+  wait_before_workloads: 180
+  # The time to wait after deploying individual workloads. Specified in seconds
+  wait_after_workloads: 180
+
+### HELM CHART REPLACEMENTS ###
+# The replacements for the Helm chart values file.
+# Can be used for any arbirary value. It will replace all instances of that value in the whole values file.
+# The replacement will be applied only when all conditions are meet. 
+# The `__EXPERIMENT_TAG__` placeholder will be replaces with the name of the variant. Additionally, it will be used as a tag for the docker images.
+# Required fields:
+#   value: str - the old value to replace
+#   replacement: str - the new value to use
+#   conditions: object - the conditions to apply the replacement. If not conditions are specified, the replacement will always run.
+#     autoscaling: bool - apply the replacement only if the autoscaling is set to true
+#     autoscaling_type: str - apply the replacement for a specific autoscaling (options: cpu, memory, or full). The `autoscaling` condition needs to be set to true.
+helm_replacements:
+  - value: "descartesresearch"
+    replacement: "registry:5000/clue"
+  - value: "nodeSelector: {}"
+    replacement: 'nodeSelector: {"scaphandre": "true"}'
+  - value: "pullPolicy: IfNotPresent"
+    replacement: "pullPolicy: Always"
+  - value: 'tag: ""'
+    replacement: 'tag: "__EXPERIMENT_TAG__"'
+  - value: "enabled: false"
+    replacement: "enabled: true"
+    conditions:
+      autoscaling: true
+  - value: "targetCPUUtilizationPercentage: 80"
+    replacement: "# targetCPUUtilizationPercentage: 80"
+    conditions:
+      autoscaling: true
+      autoscaling_type: mem
+  - value: "# targetMemoryUtilizationPercentage: 80"
+    replacement: "targetMemoryUtilizationPercentage: 80"
+    conditions:
+      autoscaling: true
+      autoscaling_type: mem
+  - value: "# targetMemoryUtilizationPercentage: 80"
+    replacement: "targetMemoryUtilizationPercentage: 80"
+    conditions:
+      autoscaling: true
+      autoscaling_type: full
+
+### RESOURCE LIMITS ###
+# A list of resource limits for individual services.
+# Can be left empty if a default limit is specified in the main config above.
+# Required fields:
+# service_name: str - the name of the service
+# limit: object - the limits for the individual service
+#   cpu: int - the cpu limit
+#   memory: int - the memory limit
+resource_limits:
+  - service_name: "teastore-auth"
+    limit:
+      cpu: 450
+      memory: 1024
+  - service_name: "teastore-webui"
+    limit:
+      cpu: 1000
+      memory: 1500
+  - service_name: "teastore-recommender"
+    limit:
+      cpu: 1000
+      memory: 1024
+  - service_name: "teastore-image"
+    limit:
+      cpu: 1000
+      memory: 1500
+  - service_name: "teastore-all"
+    limit:
+      cpu: 1000
+      memory: 2048
+
+### WORKLOADS ###
+# A list of workloads for the SUT. Required fields:
+# name: str - a short name of the variant
+# description: str - a short description of the variant 
+# timeout_duration: int - the total timeout for the workload generator
+# workload_settings: JSON - settings for the Locust workload generator. See default SUTs' configs for more detail.
+workloads:
+  - name: "shaped"
+    description: "Workload with custom load shape behavior."
+    timeout_duration: 120
+    workload_runtime: 64
+    workload_settings: {
+        "LOADGENERATOR_STAGE_DURATION": 8,
+        "LOADGENERATOR_MAX_DAILY_USERS": 100,
+      }
+    locust_files:
+      - "sut_configs/workloads/teastore/consumerbehavior.py"
+      - "sut_configs/workloads/teastore/loadshapes.py"
+      - "sut_configs/workloads/teastore/config.py"
+  - name: "rampup"
+    description: "Workload that ramps up users at a constant rate."
+    timeout_duration: 120
+    workload_runtime: 64
+    workload_settings: {
+        "LOCUST_SPAWN_RATE": 3,
+        "LOCUST_USERS": 100,
+      }
+    locust_files:
+      - "sut_configs/workloads/teastore/locustfile.py"
+  - name: "pausing"
+    description: "Workload that starts 20 pausing users, no ramp-up for the duration."
+    timeout_duration: 120
+    workload_runtime: 64
+    workload_settings: {
+            "LOCUST_SPAWN_RATE": 1,
+            "LOCUST_USERS": 10,
+            "PAUSE_BACKOFF": 120,
+      }
+    locust_files:
+      - "sut_configs/workloads/teastore/pausing_users.py"
+  - name: "fixed"
+    description: "Workload that ramps up to max users for at most 1000 requests (failed or successful), running for at most the specified duration."
+    timeout_duration: 120
+    workload_runtime: 64
+    workload_settings: {
+        "LOCUST_SPAWN_RATE": 1,
+        "LOCUST_USERS": 100,
+        "MAXIMUM_REQUESTS": 200,
+      }
+    locust_files:
+      - "sut_configs/workloads/teastore/fixed_requests.py"
+
+### VARIANTS ###
+# A list of variants for the SUT. Required fields:
+# name: str - a short name of the variant
+# description: str - a short description of the variant 
+# target_branch: str - the name of the git repository branch for the variant
+# colocated_workload: bool - if the workload should be deployed in the cluster or on host machine
+# critical_services: list[str] - a list of the names of the critical services to wait for before running the workload
+# autoscaling: enum[str] - the type of autoscaling (options: cpu, memory, full)
+variants:
+  - name: "baseline"
+    description: "Baseline experiment for the teastore application"
+    target_branch: "vanilla"
+    colocated_workload: true
+    critical_services: ["teastore-auth", "teastore-registry", "teastore-webui"]
+    autoscaling: "cpu"
+  - name: "serverless"
+    description: "Serverless experiment for the teastore application"
+    target_branch: "serverless"
+    colocated_workload: true
+    critical_services: ["teastore-registry", "teastore-webui"]
+    autoscaling: "cpu"


### PR DESCRIPTION
Adjust the Add SUT page to include "Add SUT" button and ensure the added configuration is correctly saved and selectable. Allow users to rename the SUT file to avoid always saving it as "default_sut" and to make it clear whether they're editing a default or uploaded file. Lastly, prevent the default_sut from appearing in the experiment selection dropdown, as it serves only as a UI starting point. #111 